### PR TITLE
add remove feature and make plugin work with eclipse android project

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@
                 <param name="android-package" value="com.portnou.cordova.plugin.preferences.Preferences"/>
             </feature>
         </config-file>
-        <source-file src="src/android/preferences.java" target-dir="src/com/portnou/cordova/plugin/preferences" />
+        <source-file src="src/android/Preferences.java" target-dir="src/com/portnou/cordova/plugin/preferences" />
 
     </platform>
 

--- a/src/android/Preferences.java
+++ b/src/android/Preferences.java
@@ -1,16 +1,17 @@
 package com.portnou.cordova.plugin.preferences;
 
 
+import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
-
+import org.apache.cordova.CordovaWebView;
 import org.json.JSONArray;
 import org.json.JSONException;
-import org.json.JSONObject;
 
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.preference.PreferenceManager;
 
 
 /**
@@ -18,14 +19,13 @@ import android.content.SharedPreferences.Editor;
  */
 public class Preferences extends CordovaPlugin {
     protected static Context context = null;
-    private  static final String MyPREFERENCES = "AppPrefs" ;
     private SharedPreferences sharedpreferences;
 
     @Override
     public void initialize (CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
         context = super.cordova.getActivity().getApplicationContext();
-        sharedpreferences = context.getSharedPreferences(MyPREFERENCES, Context.MODE_PRIVATE);
+        sharedpreferences = PreferenceManager.getDefaultSharedPreferences(context);
     }
     
     @Override
@@ -39,6 +39,11 @@ public class Preferences extends CordovaPlugin {
             String key = args.getString(0);
             String value = args.getString(1);
             this.put(key, value, callbackContext);
+            return true;
+        }
+        else if (action.equals("removeValue")) {
+            String key = args.getString(0);
+            this.remove(key, callbackContext);
             return true;
         }
         
@@ -56,12 +61,23 @@ public class Preferences extends CordovaPlugin {
 
     private void put(String key, String value, CallbackContext callbackContext) {
         if (key != null && key.length() > 0 && value != null && value.length() > 0) {
-            SharedPreferences.Editor editor = sharedpreferences.edit();
+            Editor editor = sharedpreferences.edit();
             editor.putString(key, value);
             editor.commit();
             callbackContext.success();
         } else {
             callbackContext.error("Expected two non-empty string arguments.");
+        }
+    }
+
+    private void remove(String key, CallbackContext callbackContext) {
+        if (key != null && key.length() > 0) {
+            Editor editor = sharedpreferences.edit();
+            editor.remove(key);
+            editor.commit();
+            callbackContext.success();
+        } else {
+            callbackContext.error("Expected one non-empty string argument.");
         }
     }
 }

--- a/src/ios/preferences.h
+++ b/src/ios/preferences.h
@@ -27,4 +27,6 @@
 
 - (void)setValue:(CDVInvokedUrlCommand*)command;
 
+- (void)removeValue:(CDVInvokedUrlCommand*)command;
+
 @end

--- a/src/ios/preferences.m
+++ b/src/ios/preferences.m
@@ -50,5 +50,18 @@
     [self.commandDelegate sendPluginResult:result
                                 callbackId:command.callbackId];
 }
+- (void)removeValue:(CDVInvokedUrlCommand*)command {
+    NSArray* arguments = [command arguments];
+    NSString *key = [arguments objectAtIndex:0];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    CDVPluginResult* result;
+
+    [defaults removeObjectForKey:key];
+
+    result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+
+    [self.commandDelegate sendPluginResult:result
+                                callbackId:command.callbackId];
+}
 
 @end

--- a/www/preferences.js
+++ b/www/preferences.js
@@ -4,10 +4,15 @@ var cordova = require('cordova');
 var Preferences = exports;
 
 Preferences.put = function(key, value, success, error) {
-    value = JSON.stringify(value);
     exec(success, error, "Preferences", "setValue", [key, value]);
 };
 
 Preferences.get = function(key, success, error) {
     exec(success, error, "Preferences", "getValue", [key]);
 };
+
+Preferences.remove = function(key, success, error) {
+    exec(success, error, "Preferences", "removeValue", [key]);
+};
+
+});


### PR DESCRIPTION
- add remove method
- doesn't json.stringify value (cordova developer has to pass string, he can use json.stringify on his side)
- Use default shared preferences on android (idea : use a cordova preference for the shared preferences name)
- make plugin work with eclipse android project :
           * Capitalize java src file
           * import missing packages